### PR TITLE
fix: capture combined command output reliably

### DIFF
--- a/internal/services/tasks/executor_service.go
+++ b/internal/services/tasks/executor_service.go
@@ -1,16 +1,16 @@
 package tasks
 
 import (
-	"github.com/engigu/baihu-panel/internal/constant"
-	"github.com/engigu/baihu-panel/internal/logger"
-	"github.com/engigu/baihu-panel/internal/utils"
-	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/engigu/baihu-panel/internal/constant"
+	"github.com/engigu/baihu-panel/internal/logger"
+	"github.com/engigu/baihu-panel/internal/utils"
 )
 
 // SettingsService 接口定义（避免循环依赖）
@@ -262,9 +262,6 @@ func (es *ExecutorService) ExecuteCommandWithOptions(command string, timeout tim
 
 	shell, args := utils.GetShellCommand(command)
 	cmd := exec.CommandContext(ctx, shell, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
 
 	// 设置工作目录
 	if workDir != "" {
@@ -276,15 +273,15 @@ func (es *ExecutorService) ExecuteCommandWithOptions(command string, timeout tim
 		cmd.Env = append(os.Environ(), envVars...)
 	}
 
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	result.End = time.Now()
 
-	result.Output = stdout.String()
+	result.Output = string(output)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			result.Error = "执行超时\n" + stderr.String()
+			result.Error = "执行超时\n"
 		} else {
-			result.Error = err.Error() + "\n" + stderr.String()
+			result.Error = err.Error()
 		}
 	} else {
 		result.Success = true


### PR DESCRIPTION
### **描述：**
本次修改修复了任务执行过程中 `stdout` 与 `stderr` 分开捕获导致的日志顺序错乱和部分错误信息丢失的问题。

**主要改动：**
* **统一输出流**：使用 `cmd.CombinedOutput()` 替代原有的双 Buffer 捕获逻辑，确保标准输出与错误信息按实际发生顺序合并。
* **修复日志丢失**：解决了某些异常场景下无法捕获 stderr 内容的 Bug，保证回显信息的完整性。