### PR TITLE
ci(github workflows): disable auto latest tag for release docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,8 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}${{ matrix.tag_suffix }}
             type=raw,value=latest${{ matrix.tag_suffix }}


### PR DESCRIPTION
add flavor: latest=false to prevent docker build from automatically building the latest tag, only build tags based on semver version