### PR TITLE
fix: surface task remark in the desktop task list view

### DIFF
--- a/web/src/views/tasks/Tasks.vue
+++ b/web/src/views/tasks/Tasks.vue
@@ -86,6 +86,10 @@ function getExecutorStatus(task: Task): 'local' | 'online' | 'offline' {
   return agent?.status === AGENT_STATUS.ONLINE ? 'online' : 'offline'
 }
 
+function getTaskNameTitle(task: Task): string {
+  return task.remark ? `${task.name}\n备注: ${task.remark}` : task.name
+}
+
 async function loadTasks() {
   loading.value = true
   try {
@@ -679,11 +683,12 @@ watch(() => route.query.agent_id, (newVal: any) => {
                 <Terminal v-else class="h-4 w-4 text-primary" />
               </div>
             </span>
-            <div class="w-56 shrink-0 flex flex-col justify-center gap-0.5 overflow-hidden">
+            <div class="w-56 shrink-0 flex flex-col justify-center gap-0.5 overflow-hidden" :title="getTaskNameTitle(task)">
               <div class="flex items-center gap-1.5 overflow-hidden">
-                <span class="font-medium truncate cursor-help" :title="task.name">{{ task.name }}</span>
+                <span class="font-medium truncate cursor-help">{{ task.name }}</span>
                 <Pin v-if="task.pin_type === 'top'" class="h-3 w-3 text-primary fill-primary shrink-0 rotate-45" />
               </div>
+              <span v-if="task.remark" class="text-[11px] leading-tight text-muted-foreground truncate">{{ task.remark }}</span>
               <div v-if="task.tags" class="flex items-center gap-1 overflow-hidden">
                 <span v-for="tag in task.tags.split(',').filter(Boolean).slice(0, 3)" :key="tag"
                   class="truncate text-[10px] leading-none px-1 py-0.5 bg-secondary text-secondary-foreground rounded border">{{ tag }}</span>

--- a/web/src/views/tasks/Tasks.vue
+++ b/web/src/views/tasks/Tasks.vue
@@ -779,18 +779,19 @@ watch(() => route.query.agent_id, (newVal: any) => {
             <div v-else-if="task.running_status === 'queued' || task.running_status === 'pending'" class="h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse shrink-0" />
             <div v-else class="h-1 w-1 rounded-full bg-muted-foreground/20 shrink-0" />
             <div class="w-12 shrink-0 text-muted-foreground tabular-nums text-[10px]">#{{ total - (currentPage - 1) * pageSize - index }}</div>
-            <div class="w-48 shrink-0 flex items-center gap-2 overflow-hidden">
+            <div class="w-48 shrink-0 flex items-center gap-2 overflow-hidden" :title="getTaskNameTitle(task)">
               <span class="shrink-0" :title="getTaskTypeTitle(task.type || 'task')">
                 <div class="relative">
                   <GitBranch v-if="task.type === TASK_TYPE.REPO" class="h-3.5 w-3.5 text-primary" />
                   <Terminal v-else class="h-3.5 w-3.5 text-primary" />
                 </div>
               </span>
-              <div class="flex flex-col min-w-0">
+              <div class="flex flex-col min-w-0 overflow-hidden">
                 <div class="flex items-center gap-1.5 overflow-hidden">
-                  <span class="font-medium truncate">{{ task.name }}</span>
+                  <span class="font-medium truncate cursor-help">{{ task.name }}</span>
                   <Pin v-if="task.pin_type === 'top'" class="h-3 w-3 text-primary fill-primary shrink-0 rotate-45" />
                 </div>
+                <span v-if="task.remark" class="text-[10px] leading-tight text-muted-foreground truncate">{{ task.remark }}</span>
                 <span v-if="task.schedule" class="text-[10px] text-muted-foreground font-mono truncate">{{ task.schedule }}</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Task remarks (备注) are now visible in the task list without consuming a new column: when `task.remark` is non-empty it renders as a muted truncated second line inside the existing name cell (the same treatment tags already get), and the name cell's tooltip carries the full remark text. The medium (sm to below xl) layout's task info block gets the same handling, so tablet and narrow-desktop users see it too.

## Why this matters

#100 had two parts; the save bug was fixed the same day (e37deac2, d187b1e1) but the remark stayed invisible in the list, and you noted there is no room for a dedicated column ("列表页面展示备注展示不下了"). This surfaces the remark with zero horizontal footprint instead of the heavier column-visibility chooser the thread floated. The small-screen card layout already showed the remark; the list layouts now match. No backend changes, the task VO already returns `remark`.

## Testing

Frontend-only change in `Tasks.vue` (+11/-5); empty remarks render nothing, long remarks truncate with the full text in the tooltip, and the large and medium branches were both checked.

Fixes #100
