### PR TITLE
fix: add missing GET /tasks/tags endpoint to OpenAPI routes

### DIFF
--- a/internal/router/openapi.go
+++ b/internal/router/openapi.go
@@ -35,6 +35,7 @@ func registerOpenAPITaskRoutes(g *gin.RouterGroup, c *Controllers) {
 		tasks.PUT("/:id", c.Task.UpdateTask)
 		tasks.DELETE("/:id", c.Task.DeleteTask)
 		tasks.POST("/stop/:logID", c.Task.StopTask)
+		tasks.GET("/tags", c.Task.GetTags)
 	}
 }
 


### PR DESCRIPTION
The GetTags handler already exists in TaskController with proper Swagger annotations, but was only registered in the internal API routes (/api/v1/tasks/tags) and missing from the OpenAPI routes (/open2api/v1/tasks/tags). This commit adds the missing route registration so the endpoint is accessible via Bearer Token.