### PR TITLE
perf: 将日志查看器滚动缓冲从默认1000行提升至5000行

### DIFF
--- a/web/src/components/LogContent.vue
+++ b/web/src/components/LogContent.vue
@@ -53,6 +53,7 @@ function initTerminal() {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     theme: getTheme(),
     allowTransparency: true,
+    scrollback: 5000,
   })
 
   fitAddon = new FitAddon()


### PR DESCRIPTION
xterm.js 默认 scrollback 仅 1000 行，当日志输出较多时早期内容无法回滚。
适当提升缓冲区容量，减少因行数超限导致的日志丢失。