### PR TITLE
refactor(notification): rename NotifyMessage.Text to Content, with backward compatibility

### DIFF
--- a/builtin/nodejs/notify.js
+++ b/builtin/nodejs/notify.js
@@ -4,8 +4,40 @@ const { URL } = require('url');
 
 /**
  * 发送通知的辅助函数 (仅使用 Node.js 标准库)
+ *
+ * @param {string} title - 通知标题
+ * @param {string} content - 通知正文
+ * @param {string} [format] - 内容格式："text"(默认), "markdown", "html"
+ * @param {string} [channelId] - 渠道ID，不传则使用环境变量 BHPKG_NOTIFY_CHANNEL
+ *
+ * @example
+ * // 最简用法
+ * baihu.notify('标题', '消息')
+ *
+ * // 指定格式
+ * baihu.notify('标题', '**粗体**', 'markdown')
+ *
+ * // 指定渠道（跳过格式）
+ * baihu.notify('标题', '消息', undefined, 'ch-xxx')
+ *
+ * // 同时指定
+ * baihu.notify('标题', '<b>粗体</b>', 'html', 'ch-xxx')
+ *
+ * // 兼容旧版调用: notify(title, text, channelId)
+ * baihu.notify('标题', '消息', 'ch-xxx')
  */
-function notify(title, text, channelId) {
+function notify(title, content, format, channelId) {
+    // 兼容旧版调用: notify(title, text, channelId)
+    // 如果只传了3个参数且第3个参数不是合法的format值，则将其视为channelId
+    // 后期移除
+    var VALID_FORMATS = ['text', 'markdown', 'html', ''];
+    if (arguments.length === 3 && VALID_FORMATS.indexOf(format) === -1) {
+        channelId = format;
+        format = '';
+    }
+
+    format = format || '';
+    channelId = channelId || '';
     const token = process.env.BHPKG_NOTIFY_TOKEN;
     const channel = process.env.BHPKG_NOTIFY_CHANNEL;
 
@@ -27,7 +59,8 @@ function notify(title, text, channelId) {
     const data = JSON.stringify({
         channel_id: cid,
         title: title || '系统通知',
-        text: text
+        content: content,
+        format: format || ''
     });
 
     const options = {

--- a/builtin/python/baihu/notify.py
+++ b/builtin/python/baihu/notify.py
@@ -2,10 +2,25 @@ import os
 import json
 import urllib.request
 
-def notify(title, text, channel_id=None):
+_VALID_FORMATS = ('text', 'markdown', 'html', '')
+
+def notify(title, content, format='', channel_id=None, **_kwargs):
     """
     发送内建通知。
+
+    :param title: 通知标题
+    :param content: 通知正文
+    :param format: 内容格式："text"(默认), "markdown", "html"
+    :param channel_id: 渠道ID，不传则使用环境变量 BHPKG_NOTIFY_CHANNEL
     """
+    # 兼容旧版: 关键字参数 text= 映射到 content
+    if 'text' in _kwargs:
+        content = _kwargs['text']
+    # 兼容旧版: 位置调用 notify(title, text, channel_id)
+    # 若第3个参数不是合法 format 且 channel_id 未显式传入，则将其视为 channel_id
+    if format and format not in _VALID_FORMATS and channel_id is None:
+        channel_id = format
+        format = ''
     token = os.environ.get("BHPKG_NOTIFY_TOKEN")
     url = os.environ.get("BHPKG_NOTIFY_URL", "http://localhost:8052/api/v1/notify/send")
     default_channel = os.environ.get("BHPKG_NOTIFY_CHANNEL")
@@ -18,7 +33,8 @@ def notify(title, text, channel_id=None):
     payload = {
         "channel_id": cid,
         "title": title,
-        "text": text
+        "content": content,
+        "format": format
     }
     
     data = json.dumps(payload).encode('utf-8')

--- a/docs/guide/examples/builtin.md
+++ b/docs/guide/examples/builtin.md
@@ -31,7 +31,17 @@ baihu builtininstall
 
 ## 消息通知示例
 
-只需要一行代码即可触发零配置推送。
+只需要一行代码即可触发零配置推送。支持指定内容格式（`text`/`markdown`/`html`）和自定义渠道。
+
+**Python:** `notify(title, content, format='', channel_id=None)`
+**Node.js:** `notify(title, content, format, channelId)`
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `title` | 是 | 通知标题 |
+| `content` | 是 | 通知正文 |
+| `format` | 否 | 内容格式：`text`(默认)、`markdown`、`html` |
+| `channel_id` / `channelId` | 否 | 渠道ID，不传则使用环境变量 `BHPKG_NOTIFY_CHANNEL` |
 
 ::: code-group
 
@@ -41,16 +51,34 @@ import baihu
 def main():
     print("正在尝试发送 Python 内建通知...")
     try:
-        # 调用内置 notify 函数
-        # 内部会自动使用环境变量进行鉴权和投递
+        # 基本用法：仅指定标题和内容
+        baihu.notify("任务标题", "通知正文内容")
+
+        # 指定 Markdown 格式
+        baihu.notify(
+            title="Python 任务提醒",
+            content="## 任务完成\n\n所有步骤已**成功**执行。",
+            format='markdown'
+        )
+
+        # 指定 HTML 格式
+        baihu.notify(
+            title="Python 任务提醒",
+            content="<h2>任务完成</h2><p>所有步骤已<b>成功</b>执行。</p>",
+            format='html'
+        )
+
+        # 显式指定渠道
         response = baihu.notify(
             title="Python 任务提醒",
-            text="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
+            content="发送到指定渠道的消息。",
+            format='text',
+            channel_id='ch-xxx'
         )
         print("发送请求已处理。")
         if response:
             print(f"服务器响应: {response}")
-            
+
     except Exception as e:
         print(f"发送过程发生异常: {e}")
 
@@ -64,13 +92,33 @@ const baihu = require('baihu');
 console.log("正在尝试发送 Node.js 内建通知...");
 
 try {
-    // 简单的一行代码即可完成推送，内置包采用异步非阻塞发送
+    // 基本用法：仅指定标题和内容
+    baihu.notify("任务标题", "通知正文内容");
+
+    // 指定 Markdown 格式
     baihu.notify(
-        "Node.js 任务提醒", 
-        "这是一条来自 Node.js 示例脚本的通知消息。无需配置 API 地址或 Token。"
+        "Node.js 任务提醒",
+        "## 任务完成\n\n所有步骤已**成功**执行。",
+        "markdown"
     );
+
+    // 指定 HTML 格式
+    baihu.notify(
+        "Node.js 任务提醒",
+        "<h2>任务完成</h2><p>所有步骤已<b>成功</b>执行。</p>",
+        "html"
+    );
+
+    // 指定渠道（跳过 format 传 undefined）
+    baihu.notify(
+        "Node.js 任务提醒",
+        "发送到指定渠道的消息。",
+        undefined,
+        "ch-xxx"
+    );
+
     console.log("发送请求已提交。");
-    
+
 } catch (e) {
     console.error(`通知失败: ${e.message}`);
 }

--- a/docs/guide/notify.md
+++ b/docs/guide/notify.md
@@ -63,8 +63,17 @@ baihu builtininstall
 ```python
 import baihu
 
-# 消息通知
+# 基本消息通知
 baihu.notify("任务标题", "通知正文内容")
+
+# 指定内容格式（text/markdown/html）
+baihu.notify("任务标题", "**加粗内容**", format='markdown')
+
+# 指定渠道
+baihu.notify("任务标题", "正文", channel_id='ch-xxx')
+
+# 完整参数
+baihu.notify("任务标题", "<b>粗体</b>", format='html', channel_id='ch-xxx')
 
 # 环境变量与任务管理（详细用法见内置库示例）
 envs = baihu.get_envs()
@@ -75,8 +84,17 @@ tasks = baihu.get_tasks()
 ```javascript
 const baihu = require('baihu');
 
-// 消息通知
+// 基本消息通知
 baihu.notify("任务标题", "通知正文内容");
+
+// 指定内容格式（text/markdown/html）
+baihu.notify("任务标题", "**加粗内容**", "markdown");
+
+// 指定渠道（跳过 format）
+baihu.notify("任务标题", "正文", undefined, "ch-xxx");
+
+// 完整参数
+baihu.notify("任务标题", "<b>粗体</b>", "html", "ch-xxx");
 
 // 环境变量与任务管理（详细用法见内置库示例）
 (async () => {
@@ -108,7 +126,7 @@ baihu.notify("任务标题", "通知正文内容");
 ```bash
 curl -X POST "http://localhost:8052/api/v1/notify/send" \
   -H "notify-token: 您的_NOTIFY_TOKEN" \
-  -d '{"channel_id":"渠道ID", "title":"标题", "text":"内容"}'
+  -d '{"channel_id":"渠道ID", "title":"标题", "content":"内容"}'
 ```
 
 ##### 基础 Python (requests)
@@ -118,7 +136,7 @@ import requests
 def send_notify(title, content):
     url = "http://localhost:8052/api/v1/notify/send"
     headers = { "notify-token": "您的_NOTIFY_TOKEN" }
-    data = {"channel_id": "您的_渠道_ID", "title": title, "text": content}
+    data = {"channel_id": "您的_渠道_ID", "title": title, "content": content}
     requests.post(url, headers=headers, json=data)
 ```
 

--- a/example/builtin/test_notify.py
+++ b/example/builtin/test_notify.py
@@ -15,7 +15,7 @@ def main():
         # 内部会自动使用 BHPKG_NOTIFY_TOKEN & BHPKG_NOTIFY_CHANNEL 进行鉴权和投递
         response = baihu.notify(
             title="Python 任务提醒",
-            text="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
+            content="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
         )
         print("发送请求已处理。")
         if response:

--- a/internal/controllers/notification_controller.go
+++ b/internal/controllers/notification_controller.go
@@ -77,8 +77,8 @@ func (nc *NotificationController) TestChannel(c *gin.Context) {
 	}
 
 	result := nc.notifyService.SendToChannel(req, &services.NotifyMessage{
-		Title: "🔔 白虎面板测试通知",
-		Text:  "如果你看到这条消息，说明通知渠道配置正确！",
+		Title:   "🔔 白虎面板测试通知",
+		Content: "如果你看到这条消息，说明通知渠道配置正确！",
 	})
 
 	utils.Success(c, result)
@@ -174,6 +174,8 @@ func (nc *NotificationController) SendNotification(c *gin.Context) {
 		ChannelID string `json:"channel_id"`
 		Title     string `json:"title"`
 		Text      string `json:"text"`
+		Content   string `json:"content"`
+		Format    string `json:"format"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, "参数错误")
@@ -185,9 +187,16 @@ func (nc *NotificationController) SendNotification(c *gin.Context) {
 		return
 	}
 
+	// 兼容旧版 text 字段：优先使用 content，为空则回退到 text
+	body := req.Content
+	if body == "" {
+		body = req.Text
+	}
+
 	result := nc.notifyService.SendByChannelID(req.ChannelID, &services.NotifyMessage{
-		Title: req.Title,
-		Text:  req.Text,
+		Title:   req.Title,
+		Content: body,
+		Format:  req.Format,
 	})
 
 	utils.Success(c, result)

--- a/internal/services/notification_service.go
+++ b/internal/services/notification_service.go
@@ -30,8 +30,9 @@ type NotifyChannel struct {
 
 // NotifyMessage 通知消息
 type NotifyMessage struct {
-	Title string `json:"title"`
-	Text  string `json:"text"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
+	Format  string `json:"format"` // text/markdown/html，为空则自动检测
 }
 
 // NotifyResult 发送结果
@@ -232,14 +233,20 @@ func (s *NotificationService) GetBindingsByEvent(bindingType, event, dataID stri
 
 // SendToChannel 使用 messenger SDK 发送通知到指定渠道
 func (s *NotificationService) SendToChannel(channel NotifyChannel, msg *NotifyMessage) *NotifyResult {
-	result, err := messenger.Send(channel.Type, messenger.ChannelConfig(channel.Config), &messenger.Message{
-		Title: msg.Title,
-		Text:  msg.Text,
-	})
+	m := &messenger.Message{Title: msg.Title}
+	switch msg.Format {
+	case "html":
+		m.HTML = msg.Content
+	case "markdown":
+		m.Markdown = msg.Content
+	default:
+		m.Text = msg.Content
+	}
+	result, err := messenger.Send(channel.Type, messenger.ChannelConfig(channel.Config), m)
 
 	payload := map[string]interface{}{
 		"title":        msg.Title,
-		"content":      msg.Text,
+		"content":      msg.Content,
 		"channel_id":   channel.ID,
 		"channel_name": channel.Name,
 		"success":      false,
@@ -529,7 +536,7 @@ func (s *NotificationService) handleEvent(bindingType string) eventbus.Handler {
 			}
 
 			go func(channel NotifyChannel, msgTitle, msgText string) {
-				result := s.SendToChannel(channel, &NotifyMessage{Title: msgTitle, Text: msgText})
+				result := s.SendToChannel(channel, &NotifyMessage{Title: msgTitle, Content: msgText})
 				if !result.Success {
 					logger.Warnf("[Notify] 发送事件 %s 到渠道 %s(%s) 失败: %s", e.Type, channel.Name, channel.Type, result.Error)
 				}


### PR DESCRIPTION
## Summary

将通知消息中的 `text` 字段重命名为 `content`，新增 `format` 参数，同时保持向后兼容。

## Changes

- **refactor(notification)**: 将 `NotifyMessage.Text` 重命名为 `Content`，保留 `text` 的向后兼容
- **feat(builtin)**: 内置通知模块中重命名 `text` → `content`，新增 `format` 参数
- **docs**: 更新通知内容参数名称，添加 format 参数示例