### PR TITLE
refactor(notification): support content and format options with backward compatibility

### DIFF
--- a/builtin/nodejs/notify.js
+++ b/builtin/nodejs/notify.js
@@ -4,22 +4,53 @@ const { URL } = require('url');
 
 /**
  * 发送通知的辅助函数 (仅使用 Node.js 标准库)
+ *
+ * @param {string} title - 通知标题
+ * @param {string} content - 通知正文
+ * @param {Object|string} [options] - 选项对象 { format, channel_id } 或格式/渠道简写
+ *
+ * @example
+ * // 基本用法
+ * baihu.notify('标题', '通知正文内容')
+ *
+ * // 指定 Markdown 格式
+ * baihu.notify('标题', '**加粗**', { format: 'markdown' })
+ *
+ * // 指定渠道
+ * baihu.notify('标题', '内容', { channel_id: 'ch-xxx' })
+ *
+ * // 简写格式
+ * baihu.notify('标题', '**加粗**', 'markdown')
+ *
+ * // 兼容旧版调用: notify(title, text, 'ch-xxx')
+ * baihu.notify('标题', '内容', 'ch-xxx')
  */
-function notify(title, text, channelId) {
-    const token = process.env.BHPKG_NOTIFY_TOKEN;
-    const channel = process.env.BHPKG_NOTIFY_CHANNEL;
+function notify(title, content, options) {
+    let format = '';
+    let channel_id = '';
 
-    if (!token || !channel) {
-        const missing = [];
-        if (!token) missing.push("BHPKG_NOTIFY_TOKEN");
-        if (!channel) missing.push("BHPKG_NOTIFY_CHANNEL");
-        throw new Error(`没有正确配置或缺少 ${missing.join(" 和 ")} 环境变量以使用 notify 函数。请在白虎面板的任务设置中配置这些 Key。`);
+    // 1. 如果 options 是字符串: 支持简写格式 (如 'markdown') 或兼容旧版渠道ID (如 'ch-xxx')
+    if (typeof options === 'string') {
+        if (['text', 'markdown', 'html'].indexOf(options) !== -1) {
+            format = options;
+        } else {
+            channel_id = options;
+        }
+    } 
+    // 2. 如果 options 是对象: 提取 format 与 channel_id
+    else if (typeof options === 'object' && options !== null) {
+        format = options.format || '';
+        channel_id = options.channel_id || options.channelId || '';
     }
 
-    const notifyUrl = process.env.BHPKG_NOTIFY_URL || 'http://localhost:8052/api/v1/notify/send';
-    const cid = channelId || channel;
+    const token = process.env.BHPKG_NOTIFY_TOKEN;
+    const defaultChannel = process.env.BHPKG_NOTIFY_CHANNEL;
+    const cid = channel_id || defaultChannel;
 
-    if (!notifyUrl || !token || !cid) return;
+    if (!token || !cid) return;
+
+    const notifyUrl = process.env.BHPKG_NOTIFY_URL || 'http://localhost:8052/api/v1/notify/send';
+    if (!notifyUrl) return;
 
     const parsedUrl = new URL(notifyUrl);
     const protocol = parsedUrl.protocol === 'https:' ? https : http;
@@ -27,10 +58,11 @@ function notify(title, text, channelId) {
     const data = JSON.stringify({
         channel_id: cid,
         title: title || '系统通知',
-        text: text
+        content: content,
+        format: format
     });
 
-    const options = {
+    const optionsHttp = {
         hostname: parsedUrl.hostname,
         port: parsedUrl.port,
         path: parsedUrl.pathname + (parsedUrl.search || ''),
@@ -42,7 +74,7 @@ function notify(title, text, channelId) {
         }
     };
 
-    const req = protocol.request(options);
+    const req = protocol.request(optionsHttp);
     req.on('error', (e) => {});
     req.write(data);
     req.end();

--- a/builtin/python/baihu/notify.py
+++ b/builtin/python/baihu/notify.py
@@ -2,10 +2,38 @@ import os
 import json
 import urllib.request
 
-def notify(title, text, channel_id=None):
+_VALID_FORMATS = ('text', 'markdown', 'html')
+
+def notify(title, content, options=None, **kwargs):
     """
     发送内建通知。
+
+    :param title: 通知标题
+    :param content: 通知正文
+    :param options: dict 选项 {"format": "markdown", "channel_id": "ch-xxx"} 或格式/渠道字符串简写
+    :param kwargs: 支持关键字传参 format='markdown', channel_id='ch-xxx', text='...'
     """
+    format_val = ''
+    channel_id = ''
+
+    # 1. 解析 options 字典或字符串简写
+    opts = {}
+    if isinstance(options, dict):
+        opts.update(options)
+    elif isinstance(options, str):
+        if options in _VALID_FORMATS:
+            format_val = options
+        else:
+            channel_id = options
+
+    opts.update(kwargs)
+
+    # 2. 提取字段并兼容旧版 text
+    if 'text' in opts and not content:
+        content = opts['text']
+    format_val = opts.get('format', format_val)
+    channel_id = opts.get('channel_id', opts.get('channelId', channel_id))
+
     token = os.environ.get("BHPKG_NOTIFY_TOKEN")
     url = os.environ.get("BHPKG_NOTIFY_URL", "http://localhost:8052/api/v1/notify/send")
     default_channel = os.environ.get("BHPKG_NOTIFY_CHANNEL")
@@ -18,14 +46,14 @@ def notify(title, text, channel_id=None):
     payload = {
         "channel_id": cid,
         "title": title,
-        "text": text
+        "content": content,
+        "format": format_val
     }
     
     data = json.dumps(payload).encode('utf-8')
     req = urllib.request.Request(url, data=data, method='POST')
     req.add_header('Content-Type', 'application/json')
     req.add_header('notify-token', token)
-    
     
     with urllib.request.urlopen(req) as resp:
         return resp.read().decode('utf-8')

--- a/docs/guide/examples/builtin.md
+++ b/docs/guide/examples/builtin.md
@@ -31,7 +31,7 @@ baihu builtininstall
 
 ## 消息通知示例
 
-只需要一行代码即可触发零配置推送。
+只需要一行代码即可触发零配置推送，支持普通文本、Markdown 以及 HTML 格式。
 
 ::: code-group
 
@@ -41,16 +41,34 @@ import baihu
 def main():
     print("正在尝试发送 Python 内建通知...")
     try:
-        # 调用内置 notify 函数
-        # 内部会自动使用环境变量进行鉴权和投递
+        # 基本调用
+        baihu.notify("任务标题", "通知正文内容")
+
+        # 指定 Markdown 格式
+        baihu.notify(
+            title="Python 任务提醒",
+            content="## 任务完成\n\n所有步骤已**成功**执行。",
+            format='markdown'
+        )
+
+        # 指定 HTML 格式
+        baihu.notify(
+            title="Python 任务提醒",
+            content="<h2>任务完成</h2><p>所有步骤已<b>成功</b>执行。</p>",
+            format='html'
+        )
+
+        # 显式指定渠道
         response = baihu.notify(
             title="Python 任务提醒",
-            text="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
+            content="发送到指定渠道的消息。",
+            format='text',
+            channel_id='ch-xxx'
         )
         print("发送请求已处理。")
         if response:
             print(f"服务器响应: {response}")
-            
+
     except Exception as e:
         print(f"发送过程发生异常: {e}")
 
@@ -64,13 +82,23 @@ const baihu = require('baihu');
 console.log("正在尝试发送 Node.js 内建通知...");
 
 try {
-    // 简单的一行代码即可完成推送，内置包采用异步非阻塞发送
-    baihu.notify(
-        "Node.js 任务提醒", 
-        "这是一条来自 Node.js 示例脚本的通知消息。无需配置 API 地址或 Token。"
-    );
+    // 基本用法：仅指定标题和内容
+    baihu.notify("任务标题", "通知正文内容");
+
+    // 指定 Markdown 格式
+    baihu.notify("Node.js 任务提醒", "## 任务完成\n\n所有步骤已**成功**执行。", { format: "markdown" });
+
+    // 指定 HTML 格式
+    baihu.notify("Node.js 任务提醒", "<h2>任务完成</h2><p>所有步骤已<b>成功</b>执行。</p>", { format: "html" });
+
+    // 指定渠道
+    baihu.notify("Node.js 任务提醒", "发送到指定渠道的消息。", { channel_id: "ch-xxx" });
+
+    // 同时指定格式与渠道
+    baihu.notify("Node.js 任务提醒", "<b>粗体</b>", { format: "html", channel_id: "ch-xxx" });
+
     console.log("发送请求已提交。");
-    
+
 } catch (e) {
     console.error(`通知失败: ${e.message}`);
 }

--- a/docs/guide/notify.md
+++ b/docs/guide/notify.md
@@ -63,8 +63,17 @@ baihu builtininstall
 ```python
 import baihu
 
-# 消息通知
+# 基本消息通知
 baihu.notify("任务标题", "通知正文内容")
+
+# 指定内容格式（text/markdown/html）
+baihu.notify("任务标题", "**加粗内容**", format='markdown')
+
+# 指定渠道
+baihu.notify("任务标题", "正文", channel_id='ch-xxx')
+
+# 完整参数
+baihu.notify("任务标题", "<b>粗体</b>", format='html', channel_id='ch-xxx')
 
 # 环境变量与任务管理（详细用法见内置库示例）
 envs = baihu.get_envs()
@@ -75,8 +84,17 @@ tasks = baihu.get_tasks()
 ```javascript
 const baihu = require('baihu');
 
-// 消息通知
+// 基本消息通知
 baihu.notify("任务标题", "通知正文内容");
+
+// 指定内容格式（text/markdown/html）
+baihu.notify("任务标题", "**加粗内容**", { format: "markdown" });
+
+// 指定渠道
+baihu.notify("任务标题", "正文", { channel_id: "ch-xxx" });
+
+// 完整参数
+baihu.notify("任务标题", "<b>粗体</b>", { format: "html", channel_id: "ch-xxx" });
 
 // 环境变量与任务管理（详细用法见内置库示例）
 (async () => {
@@ -108,17 +126,17 @@ baihu.notify("任务标题", "通知正文内容");
 ```bash
 curl -X POST "http://localhost:8052/api/v1/notify/send" \
   -H "notify-token: 您的_NOTIFY_TOKEN" \
-  -d '{"channel_id":"渠道ID", "title":"标题", "text":"内容"}'
+  -d '{"channel_id":"渠道ID", "title":"标题", "content":"内容", "format":"markdown"}'
 ```
 
 ##### 基础 Python (requests)
 ```python
 import requests
 
-def send_notify(title, content):
+def send_notify(title, content, format="text"):
     url = "http://localhost:8052/api/v1/notify/send"
     headers = { "notify-token": "您的_NOTIFY_TOKEN" }
-    data = {"channel_id": "您的_渠道_ID", "title": title, "text": content}
+    data = {"channel_id": "您的_渠道_ID", "title": title, "content": content, "format": format}
     requests.post(url, headers=headers, json=data)
 ```
 

--- a/example/builtin/test_notify.py
+++ b/example/builtin/test_notify.py
@@ -15,7 +15,7 @@ def main():
         # 内部会自动使用 BHPKG_NOTIFY_TOKEN & BHPKG_NOTIFY_CHANNEL 进行鉴权和投递
         response = baihu.notify(
             title="Python 任务提醒",
-            text="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
+            content="这是一条来自 Python 示例脚本的通知消息。调用非常简单！"
         )
         print("发送请求已处理。")
         if response:

--- a/internal/controllers/notification_controller.go
+++ b/internal/controllers/notification_controller.go
@@ -77,8 +77,8 @@ func (nc *NotificationController) TestChannel(c *gin.Context) {
 	}
 
 	result := nc.notifyService.SendToChannel(req, &services.NotifyMessage{
-		Title: "🔔 白虎面板测试通知",
-		Text:  "如果你看到这条消息，说明通知渠道配置正确！",
+		Title:   "🔔 白虎面板测试通知",
+		Content: "如果你看到这条消息，说明通知渠道配置正确！",
 	})
 
 	utils.Success(c, result)
@@ -174,6 +174,8 @@ func (nc *NotificationController) SendNotification(c *gin.Context) {
 		ChannelID string `json:"channel_id"`
 		Title     string `json:"title"`
 		Text      string `json:"text"`
+		Content   string `json:"content"`
+		Format    string `json:"format"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.BadRequest(c, "参数错误")
@@ -185,9 +187,16 @@ func (nc *NotificationController) SendNotification(c *gin.Context) {
 		return
 	}
 
+	// 兼容旧版 text 字段：优先使用 content，为空则回退到 text
+	body := req.Content
+	if body == "" {
+		body = req.Text
+	}
+
 	result := nc.notifyService.SendByChannelID(req.ChannelID, &services.NotifyMessage{
-		Title: req.Title,
-		Text:  req.Text,
+		Title:   req.Title,
+		Content: body,
+		Format:  req.Format,
 	})
 
 	utils.Success(c, result)

--- a/internal/services/notification_service.go
+++ b/internal/services/notification_service.go
@@ -30,8 +30,9 @@ type NotifyChannel struct {
 
 // NotifyMessage 通知消息
 type NotifyMessage struct {
-	Title string `json:"title"`
-	Text  string `json:"text"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
+	Format  string `json:"format"` // text/markdown/html，为空则按 text 处理
 }
 
 // NotifyResult 发送结果
@@ -232,14 +233,20 @@ func (s *NotificationService) GetBindingsByEvent(bindingType, event, dataID stri
 
 // SendToChannel 使用 messenger SDK 发送通知到指定渠道
 func (s *NotificationService) SendToChannel(channel NotifyChannel, msg *NotifyMessage) *NotifyResult {
-	result, err := messenger.Send(channel.Type, messenger.ChannelConfig(channel.Config), &messenger.Message{
-		Title: msg.Title,
-		Text:  msg.Text,
-	})
+	m := &messenger.Message{Title: msg.Title}
+	switch msg.Format {
+	case "html":
+		m.HTML = msg.Content
+	case "markdown":
+		m.Markdown = msg.Content
+	default:
+		m.Text = msg.Content
+	}
+	result, err := messenger.Send(channel.Type, messenger.ChannelConfig(channel.Config), m)
 
 	payload := map[string]interface{}{
 		"title":        msg.Title,
-		"content":      msg.Text,
+		"content":      msg.Content,
 		"channel_id":   channel.ID,
 		"channel_name": channel.Name,
 		"success":      false,
@@ -529,7 +536,7 @@ func (s *NotificationService) handleEvent(bindingType string) eventbus.Handler {
 			}
 
 			go func(channel NotifyChannel, msgTitle, msgText string) {
-				result := s.SendToChannel(channel, &NotifyMessage{Title: msgTitle, Text: msgText})
+				result := s.SendToChannel(channel, &NotifyMessage{Title: msgTitle, Content: msgText})
 				if !result.Success {
 					logger.Warnf("[Notify] 发送事件 %s 到渠道 %s(%s) 失败: %s", e.Type, channel.Name, channel.Type, result.Error)
 				}


### PR DESCRIPTION
## Summary

基于原 #154 进一步优化通知模块设计与双端 SDK 签名体验：
1. **后端服务**: 将 \NotifyMessage.Text\ 重构为 \Content\，新增 \Format\（\	ext\/\markdown\/\html\）格式分发；
2. **API 兼容**: 优先解析 \content\，回退兼容旧版 \	ext\ 参数；
3. **SDK 设计**: Node.js 与 Python SDK 统一采用 **Options 选项对象** 设计，支持命名参数（如 \{ format: 'markdown', channel_id: 'ch-xxx' }\）与简写传参，并完整兼容历史旧代码；
4. **文档与示例**: 更新内置库与通知说明文档。